### PR TITLE
도형 토글 버튼 버그 수정

### DIFF
--- a/packages/client/src/Components/Drawing.js
+++ b/packages/client/src/Components/Drawing.js
@@ -26,14 +26,19 @@ class Drawing extends Component {
     };
 
     state = {
-        shapes: ['line', 'arrow', 'square', 'circle', 'polygon'],
         selectedButton: null,
         loadedListener: null,
         isInShapeCreateMode: false,
         refresh: true,
         fillOrNotToggle1: false,
         fillOrNotToggle2: false,
-        showShapeBox: false
+        isSelectStatus: {
+            Line: false,
+            Arrow: false,
+            Rect: false,
+            Circle: false,
+            Polygon: false
+        }
     };
 
     color = undefined;
@@ -75,7 +80,7 @@ class Drawing extends Component {
         let position;
         const naver = window.naver;
         const { map, updateDrawingData, descriptionModalShow } = this.props;
-        const icons = ['line', 'arrow', 'square', 'circle', 'polygon'];
+        const icons = Object.values(constants.typeOfShape);
         const overlays = [Line, Arrow, Rect, Circle, Polygon]; // Change name of index to actual overlay name of import
         let Shape;
         let shapeIndex;
@@ -132,9 +137,6 @@ class Drawing extends Component {
                     shapeName === 'Rect'
                     || shapeName === 'Circle'
                     || shapeName === 'Line'
-                    // Shape.name === 'Rect'
-                    // || Shape.name === 'Circle'
-                    // || Shape.name === 'Line'
                 ) {
                     updateDrawingData({
                         figure,
@@ -147,8 +149,7 @@ class Drawing extends Component {
                     naver.maps.Event.removeListener(moveEvent);
                     naver.maps.Event.removeListener(leftClick);
                     this.setState({
-                        isInShapeCreateMode: false,
-                        showShapeBox: false
+                        isInShapeCreateMode: false
                     });
                     descriptionModalShow();
                 } else {
@@ -184,8 +185,7 @@ class Drawing extends Component {
                     });
                 }
                 this.setState({
-                    isInShapeCreateMode: false,
-                    showShapeBox: false
+                    isInShapeCreateMode: false
                 });
                 descriptionModalShow();
                 naver.maps.Event.removeListener(moveEvent);
@@ -202,17 +202,28 @@ class Drawing extends Component {
     };
 
     selectButton = selectedIcon => {
-        const { isInShapeCreateMode } = this.state;
+        const { isInShapeCreateMode, isSelectStatus, refresh } = this.state;
         const { descriptionModalHide } = this.props;
-        this.setState({ selectedButton: selectedIcon });
+        const resetStatus = { ...isSelectStatus };
+        for (const key in resetStatus) {
+            if (key === selectedIcon && resetStatus[key]) {
+                resetStatus[key] = false;
+            } else if (key === selectedIcon) {
+                resetStatus[key] = !resetStatus[key];
+            } else {
+                resetStatus[key] = false;
+            }
+        }
+        const newStatus = Object.assign({ ...isSelectStatus }, resetStatus);
         this.setState({
             selectedButton: selectedIcon,
             isInShapeCreateMode: !isInShapeCreateMode,
+            isSelectStatus: newStatus,
             fillOrNotToggle1: false,
-            fillOrNotToggle2: false
+            fillOrNotToggle2: false,
+            refresh: !refresh
         });
         this.createShapeTest(selectedIcon); // Enter parameter for different shape
-        this.showShape();
         descriptionModalHide();
     };
 
@@ -236,13 +247,6 @@ class Drawing extends Component {
         }
     };
 
-    showShape = () => {
-        const { showShapeBox } = this.state;
-        this.setState({
-            showShapeBox: !showShapeBox
-        });
-    };
-
     decideFactor = factorNum => {
         this.factorId = factorNum;
         this.color = constants.colorList[factorNum];
@@ -253,17 +257,16 @@ class Drawing extends Component {
             map,
             handleToggle,
             drawingData,
-            // NearByFactorItems,
             updateDrawingData
         } = this.props;
         const {
             selectedButton,
-            shapes,
             isInShapeCreateMode,
+            isSelectStatus,
             fillOrNotToggle1,
-            fillOrNotToggle2,
-            showShapeBox
+            fillOrNotToggle2
         } = this.state;
+        const shapeStatus = Object.values(isSelectStatus).some(el => el === true);
         const doNotShowTips = JSON.parse(
             sessionStorage.getItem('doNotShowTipsForDrawing')
         );
@@ -312,7 +315,7 @@ class Drawing extends Component {
         }
         return (
             <div id="drawingComponentContainer">
-                {shapes.map(shape => {
+                {Object.values(constants.typeOfShape).map(shape => {
                     return (
                         <Button
                             map={map}
@@ -327,9 +330,9 @@ class Drawing extends Component {
                         />
                     );
                 })}
-                {isInShapeCreateMode ? (
+                {shapeStatus ? (
                     <div
-                        className={'selectOption ' + (showShapeBox ? '' : 'c')}
+                        className="selectOption"
                     >
                         <div className="fillOrNot">
                             <div

--- a/packages/client/src/Components/Drawing.js
+++ b/packages/client/src/Components/Drawing.js
@@ -249,7 +249,7 @@ class Drawing extends Component {
     };
 
     decideFactor = factorNum => {
-        this.factorId = factorNum;
+        this.factorId = factorNum + 1;
         this.color = constants.colorList[factorNum];
     };
 
@@ -396,7 +396,6 @@ class Drawing extends Component {
                         className="saveCloseBtn"
                         onClick={() => {
                             this.handleRequestSave(drawingData);
-                            this.showShape();
                             // puppeteer.captureImage();
                         }}
                     >

--- a/packages/client/src/Components/Drawing.js
+++ b/packages/client/src/Components/Drawing.js
@@ -151,6 +151,7 @@ class Drawing extends Component {
                     this.setState({
                         isInShapeCreateMode: false
                     });
+                    this.selectButton();
                     descriptionModalShow();
                 } else {
                     figure.draw(lineData);
@@ -187,6 +188,7 @@ class Drawing extends Component {
                 this.setState({
                     isInShapeCreateMode: false
                 });
+                this.selectButton();
                 descriptionModalShow();
                 naver.maps.Event.removeListener(moveEvent);
                 naver.maps.Event.removeListener(leftClick);
@@ -202,7 +204,7 @@ class Drawing extends Component {
     };
 
     selectButton = selectedIcon => {
-        const { isInShapeCreateMode, isSelectStatus, refresh } = this.state;
+        const { isInShapeCreateMode, isSelectStatus } = this.state;
         const { descriptionModalHide } = this.props;
         const resetStatus = { ...isSelectStatus };
         for (const key in resetStatus) {
@@ -220,8 +222,7 @@ class Drawing extends Component {
             isInShapeCreateMode: !isInShapeCreateMode,
             isSelectStatus: newStatus,
             fillOrNotToggle1: false,
-            fillOrNotToggle2: false,
-            refresh: !refresh
+            fillOrNotToggle2: false
         });
         this.createShapeTest(selectedIcon); // Enter parameter for different shape
         descriptionModalHide();
@@ -332,7 +333,7 @@ class Drawing extends Component {
                 })}
                 {shapeStatus ? (
                     <div
-                        className="selectOption"
+                        className={'selectOption ' + (shapeStatus ? '' : 'invisible')}
                     >
                         <div className="fillOrNot">
                             <div
@@ -395,6 +396,7 @@ class Drawing extends Component {
                         className="saveCloseBtn"
                         onClick={() => {
                             this.handleRequestSave(drawingData);
+                            this.showShape();
                             // puppeteer.captureImage();
                         }}
                     >
@@ -403,7 +405,9 @@ class Drawing extends Component {
                     <button
                         type="button"
                         className="saveCloseBtn"
-                        onClick={() => handleToggle()}
+                        onClick={() => {
+                            handleToggle();
+                        }}
                     >
                         {`닫기`}
                     </button>

--- a/packages/client/src/Module/Button.js
+++ b/packages/client/src/Module/Button.js
@@ -33,7 +33,7 @@ class Button extends Component {
                         selectButton(icons);
                     }}
                 >
-                    {icons === 'line' ? (
+                    {icons === 'Line' ? (
                         <FaSlash
                             className={
                                 isSelected
@@ -41,7 +41,7 @@ class Button extends Component {
                                     : 'rotateIcon1'
                             }
                         />
-                    ) : icons === 'arrow' ? (
+                    ) : icons === 'Arrow' ? (
                         <FaArrowLeft
                             className={
                                 isSelected
@@ -49,11 +49,11 @@ class Button extends Component {
                                     : 'rotateIcon2'
                             }
                         />
-                    ) : icons === 'square' ? (
+                    ) : icons === 'Rect' ? (
                         <FaSquareFull
                             className={isSelected ? 'selectedIcon' : ''}
                         />
-                    ) : icons === 'circle' ? (
+                    ) : icons === 'Circle' ? (
                         <FaCircle
                             className={isSelected ? 'selectedIcon' : ''}
                         />

--- a/packages/client/src/Module/saveHandle.js
+++ b/packages/client/src/Module/saveHandle.js
@@ -33,6 +33,7 @@ const saveHandle = (
         processedData.title = oneShape.title; // Fixed. Go to App.js line 260 to see!
         processedData.description = oneShape.value; // Fixed
         processedData.css = JSON.stringify(figuresCss);
+        console.log('oneShape : ', oneShape);
         processedData.factor_id = oneShape.figure._factorId;
         dataSet.push(processedData);
     });

--- a/packages/client/src/less/Drawing.less
+++ b/packages/client/src/less/Drawing.less
@@ -309,9 +309,6 @@ body {
   border: 1px solid @mainColor;
   color: @mainColor;
 }
-.c {
-  height: 0;
-}
 
 @circle-width: 70px;
 

--- a/packages/client/src/less/Drawing.less
+++ b/packages/client/src/less/Drawing.less
@@ -309,6 +309,9 @@ body {
   border: 1px solid @mainColor;
   color: @mainColor;
 }
+.invisible {
+  height: 0;
+}
 
 @circle-width: 70px;
 


### PR DESCRIPTION
- 기존 버그 내용: `도형(선/화살표/사각/원/다각형)` 선택시 버튼 하단에 `fill / outline` 과 `부동산 호재 카테고리`를 선택하는 `div` 노출되어야함. 예를 들어 선 버튼을 누르고 선 버튼을 다시 클릭(toggle)하면 `div`가 노출되었다가 사라져야하고, 선->화살표 버튼을를 차례로 눌렀다면 `div`가 계속 노출되어야하지만 toggle로 처리되어 `div`가 노출되지 않음.

- Drawing.js에서 showShapeBox state 삭제함
- 도형 toggle 기능은 isSelectStatus(새로 생성함)에 따라서 toggle 처리되도록 함